### PR TITLE
Add onRunNFS.sh

### DIFF
--- a/hooks/onRunNFS.sh
+++ b/hooks/onRunNFS.sh
@@ -1,1 +1,1 @@
-mount -t nfs -o -T 192.168.122.1:$RUNNER_HOME/work $RUNNER_HOME/work
+mount -t nfs -o -T 192.168.122.1:$RUNNER_HOME/work $HOME/work

--- a/hooks/onRunNFS.sh
+++ b/hooks/onRunNFS.sh
@@ -1,0 +1,1 @@
+mount -t nfs -o -T 192.168.122.1:$RUNNER_HOME/work $RUNNER_HOME/work


### PR DESCRIPTION
As part of https://github.com/vmactions/base-vm/pull/2

OpenBSD requires its own mount command because it defaults to using UDP, however Linux's NFS server uses TCP.